### PR TITLE
fix(mspec): use `constApprox := true` when assigning schematic pre/postconditions

### DIFF
--- a/MPL/Tactics/Spec.lean
+++ b/MPL/Tactics/Spec.lean
@@ -183,17 +183,16 @@ def mSpec (goal : MGoal) (elabSpecAtWP : Expr → n (SpecTheorem × List MVarId)
     unless (← withAssignableSyntheticOpaque <| isDefEq wp wp') do
       Term.throwTypeMismatchError none wp wp' spec
 
-    let P ← instantiateMVarsIfMVarApp P
-    let Q ← instantiateMVarsIfMVarApp Q
-
-    -- often P or Q are schematic (i.e. an MVar app). Try to solve by rfl.
-    let hypsFn ← forallBoundedTelescope (← inferType P) (.some excessArgs.size) fun xs _ => do
-      mkLambdaFVars xs goal.hyps
-    let HPRfl ← withDefault <| withAssignableSyntheticOpaque <| isDefEqGuarded P hypsFn
-    let QQ'Rfl ← withDefault <| withAssignableSyntheticOpaque <| isDefEqGuarded Q Q'
-
     let P := P.betaRev excessArgs
     let spec := spec.betaRev excessArgs
+
+    -- often P or Q are schematic (i.e. an MVar app). Try to solve by rfl.
+    let P ← instantiateMVarsIfMVarApp P
+    let Q ← instantiateMVarsIfMVarApp Q
+    let (HPRfl, QQ'Rfl) ← withConfig (fun c => {c with constApprox := true}) do
+      let HPRfl ← withDefault <| withAssignableSyntheticOpaque <| isDefEqGuarded P goal.hyps
+      let QQ'Rfl ← withDefault <| withAssignableSyntheticOpaque <| isDefEqGuarded Q Q'
+      pure (HPRfl, QQ'Rfl)
 
     -- Discharge the validity proof for the spec if not rfl
     let mut prePrf : Expr → Expr := id


### PR DESCRIPTION
I discovered an issue while toying around with `mvcgen` in a proof of Lean's qsort algorithm -- [on this line](https://github.com/rish987/qsort/blob/cba0944fa1db928f88d0a726f2d8f422a67783cc/Qsort/Monadic/TerminatingSV.lean#L186), the call to `mvcgen` generates the verification condition `isTrue` which contains some unexpected metavars in the goal, and it is not able to proceed with VC generation. Not sure about an MWE, but the issue seems to be that in `mspec`, we apply the spec's precondition to the `excessArgs` before trying to assign it via `isDefEq`  (in the case that it is an mvar). So we would be trying to solve `?P $excessArgs =?= $goal.hyps`, where `$goal.hyps` is not necessarily reducible to some `f $excessArgs` that would allow us to unify `?P` with `f`.

It seems that a solution is to check `?P =?= fun .. => $goal.hyps`, where we make a constant function for the RHS with `excessArgs.size` binders. Not sure if that is the best solution, but it seems to get around the issue for now.